### PR TITLE
feat: add Python/Gymnasium-specific review criteria to code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,12 @@ jobs:
 
             Post review comments inline on the diff using the GitHub API.
             Be concise. Focus on significant issues only.
-            # CUSTOMIZE: Add stack-specific review criteria here
+            Additionally, for this Python/Gymnasium/Stable-Baselines3 codebase, also check:
+            4. Gymnasium API compliance — reset() must return (obs, info) tuple (Gymnasium 1.0+, not just obs); step() must return (obs, reward, terminated, truncated, info) 5-tuple, not the legacy 4-tuple
+            5. Reward function correctness — the reward formula must match the spec: r = -cost_weight * cost + quality_weight * quality - latency_penalty * max(0, latency - sla_threshold)
+            6. Action/observation space definitions — action space must be Discrete(n_models); observation space must be Box with the correct shape (prompt_length, prompt_complexity, queue_depths per model, time_of_day, budget_remaining)
+            7. No hardcoded model configs — new models must be defined in llm_router_env/models.py, not inline in other files
+            8. Test coverage — any changes to env.py, reward.py, or models.py must include corresponding pytest tests
 
             After posting inline comments, submit a formal review decision using the GitHub API.
             Determine whether blocking issues were found (significant bugs, security vulnerabilities, or breaking changes).


### PR DESCRIPTION
## Summary

- Replaces the `# CUSTOMIZE: Add stack-specific review criteria here` placeholder in `.github/workflows/claude-code-review.yml` with concrete, stack-aware review criteria
- The reviewer now checks for 5 additional Gymnasium/Python-specific issues on every PR:
  1. **Gymnasium API compliance** — `reset()` returns `(obs, info)`, `step()` returns 5-tuple
  2. **Reward formula correctness** — matches the spec in CLAUDE.md
  3. **Action/observation space definitions** — `Discrete(n_models)` / `Box` with correct shape
  4. **No hardcoded model configs** — models must live in `llm_router_env/models.py`
  5. **Test coverage** — changes to `env.py`, `reward.py`, or `models.py` require pytest tests

Closes #6

Generated with [Claude Code](https://claude.ai/code)
