### PR TITLE
feat: add CI workflow to gate PRs with ruff and pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest -x


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` triggered on `pull_request` (targeting `main`) and on `push` to `main`
- Installs dependencies with `pip install -e .[dev]`
- Runs `ruff check .` for linting
- Runs `pytest -x` for tests
- Uses `actions/setup-python@v5` with pip caching for faster runs

## Motivation

Closes #9. Without a CI workflow, the PR shepherd's 'Check CI' step returns no checks (trivially passes), allowing broken code to be merged silently. This workflow gives the shepherd a real required check to gate on.

Generated with [Claude Code](https://claude.ai/code)