### PR TITLE
fix: guard shepherd prompt against merging with pending/in-progress CI

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -35,10 +35,13 @@ jobs:
 
             For each non-draft PR:
             1. Check CI: gh pr checks <number> --repo ${{ github.repository }}
+               - If ANY check is in pending, in_progress, or queued state → log "CI still running, skipping PR #<number>" and skip this PR entirely (do NOT merge)
+               - If ANY check has failed → post a comment and skip
+               - Only continue to the next steps if ALL checks have completed with a passing (pass/success) terminal status
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
-            4. If CI passes and reviewDecision is APPROVED, merge:
+            4. If ALL checks passed and reviewDecision is APPROVED, merge:
                gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
             5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"


### PR DESCRIPTION
## Summary

- Adds explicit sub-instructions to step 1 of the `claude-pr-shepherd` prompt to handle non-terminal CI check states
- If **any** check is in `pending`, `in_progress`, or `queued` state, the shepherd now skips the PR entirely with a log message ("CI still running, skipping PR #N") instead of potentially merging prematurely
- If any check has failed, it posts a comment and skips
- Only proceeds to merge when **all** checks have completed with a passing terminal status
- Updates step 4 wording from "If CI passes" to "If ALL checks passed" for clarity

## Test plan

- [ ] Verify the shepherd workflow correctly skips PRs with pending checks on the next scheduled run
- [ ] Verify PRs with all-passing checks still get merged when `reviewDecision == APPROVED`
- [ ] Verify PRs with failed checks still get a comment posted

Closes #18

Generated with [Claude Code](https://claude.ai/code)
