### PR TITLE
fix: add timeout-minutes to all Claude action workflow jobs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event.pull_request.draft == false
     steps:
       - name: Run Claude Code Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     if: github.event.pull_request.draft == false
     steps:
       - name: Run Claude Code Review

--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   shepherd:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Run Claude PR Shepherd
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-proactive.yml
+++ b/.github/workflows/claude-proactive.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   proactive-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   weekly-deep-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   claude:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
## Summary

- Adds timeout-minutes to 4 Claude action workflow jobs to prevent runaway jobs from burning unlimited API credits
- Timeouts: claude.yml (30 min), claude-pr-shepherd.yml (10 min), claude-proactive.yml (15 min), claude-self-improve.yml (30 min)
- All modified YAML files validated for syntax correctness

### Why claude-code-review.yml is intentionally excluded

Adding `timeout-minutes` to `claude-code-review.yml` via PR is blocked by the OIDC security gate in `anthropics/claude-code-action@v1`. The action validates that the calling workflow file is **byte-for-byte identical to `main`** before granting API access. Any PR that modifies `claude-code-review.yml` always fails with `401 Unauthorized — Workflow validation failed`. The timeout for this file must be added directly to `main` in a separate commit outside of this PR.

Closes #22

Generated with [Claude Code](https://claude.ai/code)