### PR TITLE
fix: add concurrency group to ci.yml to cancel redundant runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Adds a `concurrency` block to `.github/workflows/ci.yml` so only one run per ref executes at a time, cancelling the in-progress run when a newer push arrives.

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

This prevents wasted runner minutes when commits are pushed rapidly or a PR merges while a CI run is still queued. Matches the same pattern used to fix `auto-tag.yml` in issue #3.

Closes #23

Generated with [Claude Code](https://claude.ai/code)