### PR TITLE
fix: add timeout-minutes: 10 to auto-tag job

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 10` to the `auto-tag` job in `.github/workflows/auto-tag.yml`
- Prevents `git push origin $NEW_TAG` and `gh release create` from hanging indefinitely on network issues or GitHub API degradations
- 10 minutes is generous for a job that only runs `git tag`, `git push`, and `gh release create`

## Changes

`.github/workflows/auto-tag.yml`: Added `timeout-minutes: 10` to the `auto-tag` job definition.

Fixes #32

Generated with [Claude Code](https://claude.ai/code)