### PR TITLE
fix: add checkout step to claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary

- Add actions/checkout@v4 with ref to pull_request.head.sha before the Claude action in claude-code-review.yml
- This gives Read, Glob, and Grep tools access to the full repository at the PR HEAD
- Matches the pattern already used in claude.yml

Fixes #38

Generated with [Claude Code](https://claude.ai/code)