### PR TITLE
fix: use --json flag in claude-pr-shepherd for reliable CI check parsing

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -34,12 +34,15 @@ jobs:
               gh pr list --repo ${{ github.repository }} --state open --json number,title,isDraft,mergeable
 
             For each non-draft PR:
-            1. Check CI: gh pr checks <number> --repo ${{ github.repository }}
-               - If ANY check is in pending, in_progress, or queued state → log "CI still running, skipping PR #<number>" and skip this PR entirely (do NOT merge)
-               - If ANY check has a status of failure, action_required, timed_out, stale, cancelled, or startup_failure → post a comment and skip
-               - Treat skipped and neutral as passing terminal states (these indicate a job legitimately did not need to run)
-               - Only continue to the next steps if ALL checks are in a terminal state AND none has failed/timed_out/action_required/stale/cancelled/startup_failure
-                 (valid passing terminal states: pass, success, skipped, neutral)
+            1. Check CI: gh pr checks <number> --repo ${{ github.repository }} --json name,status,conclusion
+               This returns a JSON array where each element has:
+               - "status": one of "queued", "in_progress", "completed"
+               - "conclusion": one of "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required" (only meaningful when status is "completed")
+               Rules (evaluate using the JSON fields, not text patterns):
+               - If ANY check has status "queued" or "in_progress" → log "CI still running, skipping PR #<number>" and skip this PR entirely (do NOT merge)
+               - If ANY check has status "completed" AND conclusion of "failure", "timed_out", "cancelled", or "action_required" → post a comment and skip
+               - A check counts as passing if: status is "completed" AND conclusion is "success", "neutral", or "skipped"
+               - Only continue to the next steps if ALL checks are in a passing terminal state (status "completed" + conclusion "success"/"neutral"/"skipped")
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."


### PR DESCRIPTION
## Summary

- Replace plain gh pr checks with --json name,status,conclusion for structured output
- Update CI check evaluation to use JSON fields (status, conclusion) instead of fragile text column patterns
- Document valid status values (queued, in_progress, completed) and conclusion values (success, failure, neutral, cancelled, skipped, timed_out, action_required)
- Clarify that only status=completed plus conclusion=success/neutral/skipped counts as a passing terminal state

Closes #39

Generated with [Claude Code](https://claude.ai/code)