### PR TITLE
fix: report merge failures in claude-pr-shepherd with PR comment

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -53,8 +53,12 @@ jobs:
                   AND user.login does NOT end with "[bot]". These are human approvals.
                c. If human approval count is 0, log "waiting for human approval on PR #<number>"
                   and skip this PR entirely (do NOT merge).
-               d. If at least one human approval exists, merge:
-                  gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
+               d. If at least one human approval exists, attempt to merge:
+                  Run: gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
+                  Capture both stdout and stderr from this command. If the command fails (non-zero
+                  exit code), post a comment on the PR explaining the failure:
+                  gh pr comment <number> --repo ${{ github.repository }} --body "Merge attempt failed: <insert the captured error output here>. Please investigate and resolve manually."
+                  If the merge succeeds, no additional comment is needed.
             5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"
             6. If reviewDecision is null or REVIEW_REQUIRED, skip and wait for the review workflow to complete


### PR DESCRIPTION
## Summary

- Adds error handling for `gh pr merge` failures in the PR shepherd workflow
- When a merge fails (non-zero exit code or error output), the shepherd now posts a comment on the PR with the captured error output
- Ensures failed merges are visible and actionable rather than silently dropped

## Changes

Modified step 4 in the shepherd prompt in `.github/workflows/claude-pr-shepherd.yml` to:
1. Capture stdout and stderr from `gh pr merge`
2. On failure, post a `gh pr comment` with the error details
3. On success, continue as before

Fixes #48

Generated with [Claude Code](https://claude.ai/code)