### PR TITLE
fix: require human approval before merging PRs in claude-pr-shepherd

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -46,8 +46,15 @@ jobs:
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
-            4. If ALL checks passed and reviewDecision is APPROVED, merge:
-               gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
+            4. If ALL checks passed and reviewDecision is APPROVED:
+               a. Fetch the PR reviews list:
+                  gh api repos/${{ github.repository }}/pulls/<number>/reviews
+               b. From the returned JSON array, count entries where state is "APPROVED"
+                  AND user.login does NOT end with "[bot]". These are human approvals.
+               c. If human approval count is 0, log "waiting for human approval on PR #<number>"
+                  and skip this PR entirely (do NOT merge).
+               d. If at least one human approval exists, merge:
+                  gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
             5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"
             6. If reviewDecision is null or REVIEW_REQUIRED, skip and wait for the review workflow to complete


### PR DESCRIPTION
## Summary

- Extends step 4 of the claude-pr-shepherd prompt to check for human approval before merging
- Fetches the PR reviews list via gh api repos/OWNER/REPO/pulls/NUMBER/reviews
- Counts entries where state is APPROVED and user.login does NOT end with [bot]
- If human approval count is 0, logs 'waiting for human approval on PR N' and skips the merge
- Only merges when at least one human reviewer has approved the PR

## Changes

**.github/workflows/claude-pr-shepherd.yml** — Step 4 now:
1. Fetches reviews from the GitHub API
2. Filters for human approvals (non-bot logins with state APPROVED)
3. Blocks the merge if no human has approved, preventing the fully-automated bot-only approval loop

Closes #47

Generated with [Claude Code](https://claude.ai/code)