### PR TITLE
fix: add issue-count gate to claude-self-improve.yml weekly scanner

### DIFF
--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -29,6 +29,16 @@ jobs:
             You are the Claude Software Factory conducting its weekly deep self-improvement scan.
             This repo IS the factory — its workflows are the product. Improving them is the primary goal.
 
+            **Before anything else — issue-count gate:**
+            Run the following command and count the results:
+              gh issue list --state open --limit 50
+
+            If the count is 20 or more, output exactly:
+              "Backlog too large (N open issues), skipping scan to avoid overwhelming the factory"
+            replacing N with the actual count, then stop immediately — do not perform any passes or file any issues.
+
+            Only continue if the open issue count is fewer than 20.
+
             This scan runs once a week (Sundays) and performs deeper analysis than the hourly scanner.
             Take your time and be thorough.
 


### PR DESCRIPTION
## Summary

- Adds an issue-count gate at the top of the prompt in `claude-self-improve.yml`
- If there are 20+ open issues, Claude logs `Backlog too large (N open issues), skipping scan to avoid overwhelming the factory` and stops without filing new issues
- Prevents the weekly deep scanner from piling on when the backlog already has more work than the factory can handle

## Changes

**`.github/workflows/claude-self-improve.yml`**: Added issue-count gate section at the start of the prompt that:
1. Runs `gh issue list --state open --limit 50`
2. Counts the results
3. Stops with a descriptive message if count >= 20
4. Only proceeds with the four-pass analysis if fewer than 20 issues are open

Fixes #53

Generated with [Claude Code](https://claude.ai/code)