### PR TITLE
fix: only count human approvals submitted after latest commit push

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -47,13 +47,19 @@ jobs:
             3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."
             4. If ALL checks passed and reviewDecision is APPROVED:
-               a. Fetch the PR reviews list:
+               a. Fetch the PR's commits list to get the most recent commit timestamp:
+                  gh api repos/${{ github.repository }}/pulls/<number>/commits
+                  Take the last entry's commit.committer.date as most_recent_commit_time.
+               b. Fetch the PR reviews list:
                   gh api repos/${{ github.repository }}/pulls/<number>/reviews
-               b. From the returned JSON array, count entries where state is "APPROVED"
-                  AND user.login does NOT end with "[bot]". These are human approvals.
-               c. If human approval count is 0, log "waiting for human approval on PR #<number>"
+               c. From the returned JSON array, count entries where state is "APPROVED"
+                  AND user.login does NOT end with "[bot]"
+                  AND submitted_at is strictly after most_recent_commit_time.
+                  These are valid post-push human approvals.
+               d. If valid human approval count is 0, log "waiting for human approval on PR #<number>
+                  (no human approval found after latest commit at <most_recent_commit_time>)"
                   and skip this PR entirely (do NOT merge).
-               d. If at least one human approval exists, merge:
+               e. If at least one valid post-push human approval exists, merge:
                   gh pr merge <number> --repo ${{ github.repository }} --rebase --delete-branch
             5. If reviewDecision is CHANGES_REQUESTED, post a comment:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude please address the review feedback and push an update"


### PR DESCRIPTION
## Summary

- Fetch the PR commit list to get the most recent commit timestamp (commit.committer.date of the last entry)
- Only count APPROVED reviews as valid if their submitted_at is strictly after the most recent commit timestamp
- Log the most recent commit time when skipping due to no post-push approval

This closes the stale approval bypass where a human could approve an earlier version of the PR, Claude could push new commits, and the shepherd would still count the old approval as satisfying the human-approval gate.

Closes #64

Generated with [Claude Code](https://claude.ai/code)