### PR TITLE
fix: add Closes #NUMBER instruction to prevent unbounded issue backlog

### DIFF
--- a/.github/workflows/claude-auto-assign.yml
+++ b/.github/workflows/claude-auto-assign.yml
@@ -49,7 +49,7 @@ jobs:
 
           if [ "$AUTHORIZED" = "true" ]; then
             gh issue comment $ISSUE_NUMBER --repo $REPO \
-              --body "@claude please implement this issue"
+              --body "@claude please implement this issue. Include Closes #${ISSUE_NUMBER} in your PR body to auto-close this issue on merge."
           else
             echo "User $ISSUE_AUTHOR not authorized, skipping"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,21 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 Always create PRs using `gh pr create`. Never substitute a compare link.
 
+Always include `Closes #ISSUE_NUMBER` in the PR body so the linked issue is auto-closed when the PR is merged.
+
 ```
 gh pr create \
   --repo OWNER/REPO \
   --title "..." \
-  --body "..." \
+  --body "$(cat <<'EOF'
+## Summary
+...
+
+Closes #ISSUE_NUMBER
+
+Generated with [Claude Code](https://claude.ai/code)
+EOF
+)" \
   --base main \
   --head <branch>
 ```


### PR DESCRIPTION
## Summary

- Updated `CLAUDE.md` PR section to explicitly require `Closes #ISSUE_NUMBER` in every PR body, with an example template showing the correct format
- Updated `.github/workflows/claude-auto-assign.yml` trigger comment to instruct Claude to include `Closes #NUMBER` using the workflow ISSUE_NUMBER env var

Without these changes, issues never auto-closed after their implementing PRs were merged, causing the open backlog to grow without bound and amplifying duplicate issue filing.

Closes #70

Generated with [Claude Code](https://claude.ai/code)