### PR TITLE
fix: restrict claude.yml triggers to authorized users only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,10 +21,14 @@ jobs:
   claude:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+       (github.actor == 'greynewell' || endsWith(github.actor, '[bot]'))) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+       (github.actor == 'greynewell' || endsWith(github.actor, '[bot]'))) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+       (github.actor == 'greynewell' || endsWith(github.actor, '[bot]'))) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+       (github.actor == 'greynewell' || endsWith(github.actor, '[bot]')))
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add `github.actor` authorization check to all event-trigger conditions in `claude.yml`
- Only `greynewell` and bot accounts (usernames ending with `[bot]`) can now trigger Claude API runs
- Applies consistently to `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events
- Eliminates the cost attack vector where any GitHub user could trigger unbounded Claude API runs by commenting `@claude`

## Changes

**`.github/workflows/claude.yml`** — lines 23–31: Each event branch now includes an actor authorization check so only the repo owner and trusted bots can trigger Claude.

This aligns the comment/review trigger authorization with the existing `claude-auto-assign.yml` ALLOWED_USERS model that already gates newly-opened issues.

## Test plan

- [ ] Verify that `greynewell` commenting `@claude` still triggers the workflow
- [ ] Verify that bot accounts (`claude[bot]`, `github-actions[bot]`) still trigger the workflow
- [ ] Verify that an arbitrary GitHub user commenting `@claude` does NOT trigger the workflow (job skipped)

Closes #79

Generated with [Claude Code](https://claude.ai/code)
