### PR TITLE
fix: add authorization guards to all Claude trigger paths in workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
-        (github.event.issue.pull_request == null ||
+        (github.event.issue.pull_request == '' ||
          github.event.comment.user.login == github.repository_owner ||
          github.event.comment.user.type == 'Bot')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
@@ -31,7 +31,9 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
         (github.event.review.user.login == github.repository_owner ||
          github.event.review.user.type == 'Bot')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.sender.login == github.repository_owner ||
+         github.event.sender.type == 'Bot'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,8 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.user.login == github.repository_owner ||
+         github.event.comment.user.type == 'Bot')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        (github.event.review.user.login == github.repository_owner ||
+         github.event.review.user.type == 'Bot')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     steps:
       - name: Checkout

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,6 +20,13 @@ permissions:
 jobs:
   claude:
     runs-on: ubuntu-latest
+    # Authorization rules:
+    # - issue_comment on a plain issue: any user may invoke @claude
+    #   (pull_request field is absent on plain issues, which returns '' in GHA expressions)
+    # - issue_comment on a PR: owner or Bot only
+    # - pull_request_review_comment: owner or Bot only
+    # - pull_request_review: owner or Bot only
+    # - issues (opened/assigned): owner or Bot only
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
         (github.event.issue.pull_request == '' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,10 @@ jobs:
   claude:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.issue.pull_request == null ||
+         github.event.comment.user.login == github.repository_owner ||
+         github.event.comment.user.type == 'Bot')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
         (github.event.comment.user.login == github.repository_owner ||
          github.event.comment.user.type == 'Bot')) ||


### PR DESCRIPTION
## Summary

This PR secures all Claude trigger paths in `.github/workflows/claude.yml` by adding authorization guards so that only the repository owner and Bot accounts can invoke Claude.

### Changes Made

| Trigger | Before | After |
|---------|--------|-------|
| `issue_comment` on a **plain issue** | Any `@claude` mention | Any `@claude` mention (unchanged) |
| `issue_comment` on a **PR** | Any `@claude` mention (bypass) | Owner or Bot only |
| `pull_request_review_comment` | Any `@claude` mention (bypass) | Owner or Bot only |
| `pull_request_review` | Any `@claude` mention (bypass) | Owner or Bot only |
| `issues` (opened/assigned) | Any `@claude` mention (bypass) | Owner or Bot only |

### Details

- **`pull_request_review` and `pull_request_review_comment`**: Added owner/Bot guard — the initial motivation for this PR (closes #85).
- **`issue_comment` on PRs**: Distinguished from issue comments using `github.event.issue.pull_request == ''` (empty string when absent, object when on a PR). PR comments now require owner/Bot; plain issue comments remain unrestricted.
- **`issues` trigger**: Added owner/Bot guard via `github.event.sender` to prevent arbitrary users from invoking Claude by creating issues with `@claude` in the body or title.
- **Null check fix**: Used `== ''` (empty string) instead of `== null` because GitHub Actions expressions return `''` for absent payload fields, not `null`.

### Why these additional restrictions?

Prior review rounds identified that restricting only `pull_request_review` and `pull_request_review_comment` left easy bypasses: any user could still invoke Claude via a regular PR comment (`issue_comment`) or by opening an issue (`issues`). All trigger paths are now consistently hardened.

Closes #85

Generated with [Claude Code](https://claude.ai/code)