### PR TITLE
fix: use --pretty=%B in auto-tag to detect BREAKING CHANGE in commit body/footer

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -45,7 +45,7 @@ jobs:
             elif echo "$MSG" | grep -qE "^fix(\(.+\))?:" && [ "$BUMP" != "minor" ]; then
               BUMP="patch"
             fi
-          done < <(git log "$LOG_RANGE" --pretty=%s)
+          done < <(git log "$LOG_RANGE" --pretty=%B)
 
           if [ "$BUMP" = "major" ]; then
             MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0


### PR DESCRIPTION
## Summary

- Fixes the auto-tagger silently downgrading BREAKING CHANGE commits that use the footer style (e.g. commit body contains `BREAKING CHANGE: /v1 removed`) to PATCH/MINOR bumps
- Changes `git log --pretty=%s` to `--pretty=%B` so every line of every commit (subject, body, footers) is scanned
- No change to the existing grep patterns — the `BREAKING CHANGE` regex was already unanchored and works correctly; only the input was restricted to subject lines

## Test plan

- [ ] Merge a commit with a footer-style `BREAKING CHANGE:` in the body — auto-tag should bump MAJOR
- [ ] Merge a regular `feat:` commit — auto-tag should still bump MINOR
- [ ] Merge a `fix:` commit — auto-tag should still bump PATCH
- [ ] Merge a `feat!:` (subject bang) commit — auto-tag should still bump MAJOR

Closes #84

Generated with [Claude Code](https://claude.ai/code)