### PR TITLE
fix: add serializing concurrency group to auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary

Adds a serializing `concurrency` block to `auto-tag.yml` to prevent the race condition described in #92.

- `group: auto-tag` — all auto-tag runs share the same queue
- `cancel-in-progress: false` — the second run **queues** (does not cancel), so after the first run pushes its tag, the second run starts fresh and reads the updated `LATEST`, computing the correct incremental bump

## Changes

`.github/workflows/auto-tag.yml`: added top-level `concurrency` block

```yaml
concurrency:
  group: auto-tag
  cancel-in-progress: false
```

Closes #92

Generated with [Claude Code](https://claude.ai/code)