### PR TITLE
fix: add --limit 100 to gh pr list in PR shepherd workflow

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -31,7 +31,7 @@ jobs:
             You are a PR shepherd for the repo ${{ github.repository }}.
 
             List all open, non-draft PRs:
-              gh pr list --repo ${{ github.repository }} --state open --json number,title,isDraft,mergeable
+              gh pr list --repo ${{ github.repository }} --state open --json number,title,isDraft,mergeable --limit 100
 
             For each non-draft PR:
             1. Check CI: gh pr checks <number> --repo ${{ github.repository }} --json name,status,conclusion


### PR DESCRIPTION
## Summary

- Adds `--limit 100` to the `gh pr list` command in the shepherd prompt (line 34 of `.github/workflows/claude-pr-shepherd.yml`)
- Prevents silent truncation of open PRs beyond the default 30-result limit
- Ensures all open PRs are evaluated on each 15-minute shepherd tick, even when the backlog exceeds 30 concurrent PRs

Fixes #95

Generated with [Claude Code](https://claude.ai/code)