### PR TITLE
fix: replace type:markdown claude trigger with type:textarea in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,8 +20,10 @@ body:
     attributes:
       label: Additional context
       description: Logs, screenshots, related code paths.
-  - type: markdown
+  - type: textarea
+    id: claude_trigger
     attributes:
-      value: |
-        ---
-        @claude please implement this
+      label: ''
+      value: '@claude please implement this'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -15,8 +15,10 @@ body:
     attributes:
       label: Additional context
       description: Anything else Claude should know — files to look at, constraints, related issues.
-  - type: markdown
+  - type: textarea
+    id: claude_trigger
     attributes:
-      value: |
-        ---
-        @claude please implement this
+      label: ''
+      value: '@claude please implement this'
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

- Replaced the `type: markdown` block in `.github/ISSUE_TEMPLATE/bug.yml` and `.github/ISSUE_TEMPLATE/feature.yml` with a `type: textarea` block
- GitHub's form system strips `type: markdown` content from submitted issue bodies, so the `@claude please implement this` trigger was silently absent in all template-filed issues
- The new `type: textarea` with `value: '@claude please implement this'` is included in the submitted body, restoring the self-improvement loop

Closes #99

Generated with [Claude Code](https://claude.ai/code)