### PR TITLE
docs: document branch protection prerequisite for PR shepherd loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,23 @@ When creating a GitHub issue, always include `@claude` at the end of the body:
 4. `claude-pr-shepherd.yml` merges when CI passes
 5. `auto-tag.yml` tags the release
 6. Repeat
+
+### Branch Protection Prerequisite
+
+`claude-pr-shepherd.yml` merges PRs only when `reviewDecision == APPROVED`. GitHub sets
+`reviewDecision` to a non-null value **only when branch protection rules are active**. Without
+branch protection rules, GitHub returns `reviewDecision: null` for every PR, causing the shepherd
+to silently skip all PRs forever and stalling the loop.
+
+**Required setup** — on `main`, enable a branch protection rule with at least one of:
+- **Require a pull request before merging** → **Required approving reviews: 1**
+
+To configure: Settings → Branches → Add branch ruleset (or classic rule) for `main` → enable
+"Require a pull request before merging" with at least 1 required approving review.
+
+If the self-improvement loop appears stalled (no PRs ever merge), check that this rule is in place.
+Run the following to inspect current `reviewDecision` values:
+```
+gh pr list --state open --json number,title,reviewDecision
+```
+If all show `"reviewDecision": null`, the branch protection rule is missing.


### PR DESCRIPTION
## Summary

- Adds a **Branch Protection Prerequisite** subsection to the Self-Improvement Loop section in CLAUDE.md
- Explains that `claude-pr-shepherd.yml` merges PRs only when `reviewDecision == APPROVED`, which GitHub only returns when branch protection rules are active
- Documents the required setup (Settings → Branches → require at least 1 approving review on `main`)
- Includes a diagnostic `gh pr list` command operators can run to detect this misconfiguration

## Problem

Without branch protection rules, GitHub returns `reviewDecision: null` for all PRs. The shepherd treats `null` as skip-and-wait, causing the self-improvement loop to silently stall forever since `reviewDecision` can never become `APPROVED`.

## Changes

- `CLAUDE.md`: added 20-line "Branch Protection Prerequisite" subsection with setup instructions and diagnostic command

Fixes #116

Generated with [Claude Code](https://claude.ai/code)
