### PR TITLE
fix: guard against empty checks array in claude-pr-shepherd

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -39,6 +39,7 @@ jobs:
                - "status": one of "queued", "in_progress", "completed"
                - "conclusion": one of "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required" (only meaningful when status is "completed")
                Rules (evaluate using the JSON fields, not text patterns):
+               - If the checks JSON array has ZERO elements → log "no check runs found yet, skipping PR #<number>" and skip this PR entirely (do NOT merge)
                - If ANY check has status "queued" or "in_progress" → log "CI still running, skipping PR #<number>" and skip this PR entirely (do NOT merge)
                - If ANY check has status "completed" AND conclusion of "failure", "timed_out", "cancelled", or "action_required" → post a comment and skip
                - A check counts as passing if: status is "completed" AND conclusion is "success", "neutral", or "skipped"


### PR DESCRIPTION
Fixes #115

When gh pr checks returns an empty array (before GitHub creates the first check run), the previous rules evaluated vacuously true — no failing checks, so no skip — causing premature merge.

Adds an explicit guard as the first rule in the shepherd prompt: if the checks JSON array has zero elements, log 'no check runs found yet, skipping PR #number' and skip the PR entirely.

Generated with [Claude Code](https://claude.ai/code)