### PR TITLE
fix: make training reproducible with --seed across all episodes

### DIFF
--- a/llm_router_env/env.py
+++ b/llm_router_env/env.py
@@ -66,6 +66,7 @@ class LLMRouterEnv(gym.Env):
         self.initial_budget = budget
         self.max_queue_depth = max_queue_depth
         self._seed = seed
+        self._episode_count: int = 0
 
         n_models = len(self.models)
         # obs: [prompt_length, prompt_complexity, *queue_depths, time_of_day, budget_remaining, quality_required]
@@ -100,7 +101,12 @@ class LLMRouterEnv(gym.Env):
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict]:
         super().reset(seed=seed)
-        rng_seed = seed if seed is not None else self._seed
+        if seed is not None:
+            # Explicit seed resets the episode sequence
+            self._seed = seed
+            self._episode_count = 0
+        rng_seed = self._seed + self._episode_count if self._seed is not None else None
+        self._episode_count += 1
         self._rng = np.random.default_rng(rng_seed)
         self._traffic = TrafficGenerator(rng=self._rng)
 

--- a/scripts/train_ppo.py
+++ b/scripts/train_ppo.py
@@ -12,7 +12,7 @@ import llm_router_env  # noqa: F401 — registers LLMRouter-v0
 
 
 def make_env(seed: int = 0):
-    env = gym.make("LLMRouter-v0", episode_length=1000)
+    env = gym.make("LLMRouter-v0", episode_length=1000, seed=seed)
     env = Monitor(env)
     env.reset(seed=seed)
     return env


### PR DESCRIPTION
## Summary

- Pass `seed=seed` to `gym.make()` in `scripts/train_ppo.py` so `LLMRouterEnv.__init__` stores `self._seed` (previously it was always `None`)
- Add `_episode_count` to `LLMRouterEnv.__init__` to track episode number
- Update `reset()` in `llm_router_env/env.py` to derive a deterministic per-episode seed as `base_seed + episode_count` when no explicit seed is provided — ensures reproducibility while keeping episodes varied

**Before:** `make_env(seed=42)` set `self._seed=None`; all SB3 episode resets after the first used `np.random.default_rng(None)` (non-deterministic).

**After:** `self._seed=42` is stored at construction; each episode `N` uses `rng_seed = 42 + N`, giving identical training trajectories for identical `--seed` values.

## Test plan

- [ ] `ruff check .` passes
- [ ] `pytest -x` passes
- [ ] Two runs with identical `--seed` produce the same reward trajectory

Closes #117

Generated with [Claude Code](https://claude.ai/code)
