### PR TITLE
fix: use SeedSequence in reset() to produce varied but reproducible episodes

### DIFF
--- a/llm_router_env/env.py
+++ b/llm_router_env/env.py
@@ -65,7 +65,7 @@ class LLMRouterEnv(gym.Env):
         self.episode_length = episode_length
         self.initial_budget = budget
         self.max_queue_depth = max_queue_depth
-        self._seed = seed
+        self._seed_seq = np.random.SeedSequence(seed) if seed is not None else None
 
         n_models = len(self.models)
         # obs: [prompt_length, prompt_complexity, *queue_depths, time_of_day, budget_remaining, quality_required]
@@ -100,8 +100,12 @@ class LLMRouterEnv(gym.Env):
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict]:
         super().reset(seed=seed)
-        rng_seed = seed if seed is not None else self._seed
-        self._rng = np.random.default_rng(rng_seed)
+        if seed is not None:
+            self._rng = np.random.default_rng(seed)
+        elif self._seed_seq is not None:
+            self._rng = np.random.default_rng(self._seed_seq.spawn(1)[0])
+        else:
+            self._rng = np.random.default_rng()
         self._traffic = TrafficGenerator(rng=self._rng)
 
         self._step_count = 0


### PR DESCRIPTION
## Summary

- Replaces `self._seed` with `self._seed_seq = np.random.SeedSequence(seed)` in `__init__`
- Updates `reset()` to spawn a unique child `SeedSequence` on each unseeded call, giving every episode a distinct RNG state
- Explicit `seed=` arguments passed to `reset()` still take precedence (full Gymnasium API compatibility)
- Adds `TestSeedSequence` test class covering: varied episodes, reproducibility across two identically-seeded envs, unseeded env, and explicit reset-seed override

Fixes #124

Generated with [Claude Code](https://claude.ai/code)
