### PR TITLE
fix: use correct field names in claude-pr-shepherd CI check command

### DIFF
--- a/.github/workflows/claude-pr-shepherd.yml
+++ b/.github/workflows/claude-pr-shepherd.yml
@@ -34,15 +34,15 @@ jobs:
               gh pr list --repo ${{ github.repository }} --state open --json number,title,isDraft,mergeable
 
             For each non-draft PR:
-            1. Check CI: gh pr checks <number> --repo ${{ github.repository }} --json name,status,conclusion
+            1. Check CI: gh pr checks <number> --repo ${{ github.repository }} --json name,state
                This returns a JSON array where each element has:
-               - "status": one of "queued", "in_progress", "completed"
-               - "conclusion": one of "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required" (only meaningful when status is "completed")
+               - "name": the check name
+               - "state": one of "pass", "fail", "pending", "skipping", "cancel"
                Rules (evaluate using the JSON fields, not text patterns):
-               - If ANY check has status "queued" or "in_progress" → log "CI still running, skipping PR #<number>" and skip this PR entirely (do NOT merge)
-               - If ANY check has status "completed" AND conclusion of "failure", "timed_out", "cancelled", or "action_required" → post a comment and skip
-               - A check counts as passing if: status is "completed" AND conclusion is "success", "neutral", or "skipped"
-               - Only continue to the next steps if ALL checks are in a passing terminal state (status "completed" + conclusion "success"/"neutral"/"skipped")
+               - If ANY check has state "pending" → log "CI still running, skipping PR #<number>" and skip this PR entirely (do NOT merge)
+               - If ANY check has state "fail" or "cancel" → post a comment and skip
+               - A check counts as passing if: state is "pass" or "skipping"
+               - Only continue to the next steps if ALL checks are in a passing terminal state (state "pass" or "skipping")
             2. Check review status: gh pr view <number> --repo ${{ github.repository }} --json reviewDecision,mergeable
             3. If mergeable is false (merge conflicts exist), post a comment and skip to the next PR:
                gh pr comment <number> --repo ${{ github.repository }} --body "@claude this PR has merge conflicts. Please rebase onto main and push an update."


### PR DESCRIPTION
## Summary

This is a minimal hotfix to break the circular dependency blocking PR #87.

The shepherd workflow uses invalid field names with gh pr checks --json.

Before (broken): gh pr checks --json name,status,conclusion
'status' and 'conclusion' are not valid fields - the command exits with code 1.

After (fixed): gh pr checks --json name,state
The valid fields are 'name' and 'state', where state takes values: pass, fail, pending, skipping, cancel.

## Impact

When the command failed, the shepherd interpreted it as a CI failure and posted spurious 'CI check failed' comments on every open PR every 15 minutes - even when CI was actually passing.

## Relationship to PR #87

PR #87 also contains this fix (commit 61c4e4d), plus the original feature (raise ValueError when models=[]). However, PR #87 cannot be merged by the shepherd because the shepherd is broken.

Merging this minimal PR first fixes the shepherd on main, which then allows the shepherd to correctly evaluate and merge PR #87.

Generated with Claude Code