### PR TITLE
fix: remove issues.opened trigger to enforce authorization

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [assigned]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
## Summary

- Removes `opened` from the `issues` trigger types in `.github/workflows/claude.yml`
- Previously, any public user could trigger Claude by filing an issue with `@claude` in the body, bypassing the `ALLOWED_USERS` authorization check in `claude-auto-assign.yml`
- Also eliminates the double-trigger bug (#129) where authorized users caused two concurrent Claude runs

## Changes

The intended flow (per CLAUDE.md) is: issue filed → `claude-auto-assign.yml` (auth check) → authorized comment → `claude.yml`. Removing `opened` enforces this and makes `claude-auto-assign.yml` the sole authorized entry point.

Fixes #131, related to #129

Generated with [Claude Code](https://claude.ai/code)