### PR TITLE
docs: update Self-Improvement Loop step 4 to note human approval requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,6 @@ When creating a GitHub issue, always include `@claude` at the end of the body:
 1. `claude-proactive.yml` (hourly) and `claude-self-improve.yml` (weekly) scan for issues
 2. Issues trigger `claude-auto-assign.yml` → `claude.yml` implements them
 3. `claude-code-review.yml` reviews the PR
-4. `claude-pr-shepherd.yml` merges when CI passes
+4. `claude-pr-shepherd.yml` merges when CI passes and a human approves
 5. `auto-tag.yml` tags the release
 6. Repeat


### PR DESCRIPTION
## Summary

- Updates CLAUDE.md Self-Improvement Loop step 4 from "merges when CI passes" to "merges when CI passes and a human approves"
- Reflects actual behavior introduced in fc8a3f0 where the shepherd requires both CI passing and at least one non-bot APPROVE review before merging

## Why

Claude agents reading CLAUDE.md would expect PRs to auto-merge on CI pass alone. In reality, PRs wait for human review. This documentation gap could cause confusion, missing reviewer guidance in PR descriptions, and spurious "stuck PR" issues during weekly self-improve scans.

Closes #132

Generated with [Claude Code](https://claude.ai/code)