### PR TITLE
fix: prevent orphaned inline comments from cancelled review runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,11 +13,12 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   claude-code-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
       - name: Run Claude Code Review
@@ -27,6 +28,11 @@ jobs:
           allowed_bots: "claude[bot],github-actions[bot]"
           claude_args: '--allowedTools "Bash(gh pr view:*),Bash(gh api:*),Read,Glob,Grep"'
           prompt: |
+            Before posting any new inline review comments, clean up stale bot inline review comments left by previous cancelled runs on this PR. Run the following to find existing bot comments:
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --paginate --jq '.[] | select(.user.login == "github-actions[bot]" or .user.login == "claude[bot]") | .id'
+            For each comment ID returned, delete it (ignore errors if already gone):
+              gh api repos/${{ github.repository }}/pulls/comments/<id> --method DELETE
+
             Review this pull request for:
             1. Correctness and logic errors
             2. Security vulnerabilities


### PR DESCRIPTION
## Summary

Changes to prevent orphaned inline comments when review jobs are cancelled mid-flight.

## Changes to .github/workflows/claude-code-review.yml

1. cancel-in-progress changed to false - ensures reviews always run to completion; new pushes queue rather than kill in-flight runs
2. timeout-minutes: 10 added on the job - safety valve so jobs do not run indefinitely
3. Prompt cleanup step added - before posting new inline comments, Claude fetches all existing bot review comments via gh api and deletes them, eliminating stale/duplicate threads

## Test plan
- [ ] Push to a PR while a review is already running, new review should queue rather than cancel the running one
- [ ] Verify that on the next review run, stale bot inline comments from previous runs are deleted before new ones are posted
- [ ] Verify reviews always complete with a formal APPROVE or REQUEST_CHANGES decision

Fixes #153

Generated with [Claude Code](https://claude.ai/code)