### PR TITLE
docs: add --reviewer flag to gh pr create template in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,13 +46,18 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 Always create PRs using `gh pr create`. Never substitute a compare link.
 
+Always include `--reviewer` to request a human review — this is required for the
+shepherd merge gate (`claude-pr-shepherd.yml`) to pass, which blocks on at least
+one non-bot "APPROVED" review before merging.
+
 ```
 gh pr create \
   --repo OWNER/REPO \
   --title "..." \
   --body "..." \
   --base main \
-  --head <branch>
+  --head <branch> \
+  --reviewer <REVIEWER>   # CUSTOMIZE: repo owner login or team (e.g. greynewell)
 ```
 
 ## Issues


### PR DESCRIPTION
## Summary

- Adds `--reviewer` flag to the `gh pr create` command template in CLAUDE.md
- Adds an explanatory note that `--reviewer` is required for the shepherd merge gate to function correctly
- Without `--reviewer`, human gatekeepers receive no proactive GitHub notification that their review is needed, causing PRs to silently accumulate in a "waiting for human approval" state

## Changes

**CLAUDE.md** — Updated the Pull Requests section to:
1. Add a prose note explaining _why_ `--reviewer` is mandatory (shepherd merge gate requires ≥1 non-bot APPROVED review)
2. Add `--reviewer <REVIEWER>` to the `gh pr create` template with a customization comment

**Note:** The issue also requested updating `.github/workflows/claude.yml`. That file cannot be modified by Claude due to GitHub App workflow permission restrictions.

Closes #155

Generated with [Claude Code](https://claude.ai/code)